### PR TITLE
Fix for commonjs/browserify environments

### DIFF
--- a/leaflet.tilelayer.fallback-src.js
+++ b/leaflet.tilelayer.fallback-src.js
@@ -129,7 +129,7 @@
 
 	// Supply with a factory for consistency with Leaflet.
 	L.tileLayer.fallback = function (urlTemplate, options) {
-		return new TL.Fallback(urlTemplate, options);
+		return new FallbackTileLayer(urlTemplate, options);
 	};
 
 	// Just return a value to define the module export.


### PR DESCRIPTION
Hello. Thanks for writing this library!

TL.Fallback does not get assigned in commonjs/requirejs environments. This change updates the Leaflet constructor so it works in those environments.
