### PR TITLE
Do an explicit undefined check on fallback zoom

### DIFF
--- a/src/fallback.js
+++ b/src/fallback.js
@@ -30,7 +30,7 @@ L.TileLayer.Fallback = L.TileLayer.extend({
 		var layer = this, // `this` is bound to the Tile Layer in L.TileLayer.prototype.createTile.
 			originalCoords = tile._originalCoords,
 			currentCoords = tile._currentCoords = tile._currentCoords || layer._createCurrentCoords(originalCoords),
-			fallbackZoom = tile._fallbackZoom = (tile._fallbackZoom || originalCoords.z) - 1,
+			fallbackZoom = tile._fallbackZoom = tile._fallbackZoom === undefined ? originalCoords.z - 1 : tile._fallbackZoom - 1,
 			scale = tile._fallbackScale = (tile._fallbackScale || 1) * 2,
 			tileSize = layer.getTileSize(),
 			style = tile.style,


### PR DESCRIPTION
Hey @ghybs , 

Thanks for the awesome tile fallback library!

I was playing around when my tile server started erroring out, and I think there's a bug when minNativeZoom is set to zero, and leaflet fails to fetch any tiles.

If minNativeZoom is set to zero and you can't receive any tiles from your tile source you'll enter this loop:

fallbackZoom reaches 1
tile._fallbackZoom becomes 0
0 is not less than 0, so fallbackZoom < layer.options.minNativeZoom is false, and we don't return the error tile.

... so we request a tile and loop around

tile._fallbackZoom is 0, which is falsy, so we set tile._fallbackZoom to originalCoords.z -1. We begin our loop again. 

By checking for an explicit undefined value, we won't hit that loop -- tile._fallbackZoom will be set to -1, it will be less than zero, and we'll set the error tile.